### PR TITLE
Return error when disconnected

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -31,7 +31,14 @@ impl<'a> Request<'a> {
         let _ = self.stream.flush();
 
         let mut line = String::new();
-        try!(self.stream.read_line(&mut line));
+        match self.stream.read_line(&mut line) {
+            Ok(e) => {
+                if e == 0 {
+                    return Err(BeanstalkdError::ConnectionError)
+                }
+            },
+            Err(_) => return Err(BeanstalkdError::RequestError)
+        };
         let line_segments: Vec<&str> = line.trim().split(' ').collect();
         let status_str = try_option!(line_segments.first());
         let status = match *status_str {

--- a/src/request.rs
+++ b/src/request.rs
@@ -32,8 +32,9 @@ impl<'a> Request<'a> {
 
         let mut line = String::new();
         match self.stream.read_line(&mut line) {
-            Ok(e) => {
-                if e == 0 {
+            Ok(bytes_read) => {
+                // Zero bytes read indicates the TCP connection was closed.
+                if bytes_read == 0 {
                     return Err(BeanstalkdError::ConnectionError)
                 }
             },


### PR DESCRIPTION
Jira: https://finhaven.atlassian.net/browse/P2P-798

* This modification sets up a re-connect attempt from the application layer.
* The application layer is notified of an error when attempting to send a command message to beanstalkd but the queue happens to not be available.